### PR TITLE
Structure servo calibration in a table

### DIFF
--- a/ESP32_orgel_midi_in_servoboard/ESP32_orgel_midi_in_servoboard.ino
+++ b/ESP32_orgel_midi_in_servoboard/ESP32_orgel_midi_in_servoboard.ino
@@ -25,8 +25,8 @@ struct servoCalibration {
   int servoIndex;
   int onPWM;
   int offPWM;
-}
-std::map<int, struct servoCalibration> servoMap;
+};
+std::map<int, servoCalibration> servoMap;
 
 /* Calibration function
 void controlchange(byte channel, byte number, byte value){
@@ -75,18 +75,22 @@ void setupServoMap() {
 void noteOn(byte channel, byte pitch, byte velocity){
   Serial.println(pitch);
 
-  servoData = servoMap.find(pitch);
+  auto servoData = servoMap.find(pitch);
   if(servoData != servoMap.end()) {
-    servoControllers[servoData.controllerIndex].setPWM(servoData.servoIndex, 0, servoData.onPWM);
+    servoControllers[servoData->second.controllerIndex].setPWM(
+      servoData->second.servoIndex, 0, servoData->second.onPWM
+    );
   } else {
-    Serial.println("Unmapped MIDI key!")
+    Serial.println("Unmapped MIDI key!");
   }
 }
 
 void noteOff(byte channel, byte pitch, byte velocity){
-  servoData = servoMap.find(pitch);
+  auto servoData = servoMap.find(pitch);
   if(servoData != servoMap.end()) {
-    servoControllers[servoData.controllerIndex].setPWM(servoData.servoIndex, 0, servoData.onPWM);
+    servoControllers[servoData->second.controllerIndex].setPWM(
+      servoData->second.servoIndex, 0, servoData->second.onPWM
+    );
   }
 }
 

--- a/ESP32_orgel_midi_in_servoboard/ESP32_orgel_midi_in_servoboard.ino
+++ b/ESP32_orgel_midi_in_servoboard/ESP32_orgel_midi_in_servoboard.ino
@@ -13,44 +13,20 @@
 #include <MIDI.h>
 #include <Wire.h>
 #include <Adafruit_PWMServoDriver.h>
+#include <map>
 
 //Add board
-Adafruit_PWMServoDriver pca9685 = Adafruit_PWMServoDriver(0x40);
-Adafruit_PWMServoDriver pca9686 = Adafruit_PWMServoDriver(0x41);
-
-//cluster 1
-#define SER0  0   
-#define SER1  1  
-#define SER2  2  
-#define SER3  3  
-#define SER4  4 
-#define SER5  5 
-#define SER6  6  
-#define SER7  7  
-
-#define SER8  8
-#define SER9  9 
-#define SER10  10
-#define SER11  11
-#define SER12  12 
-#define SER13  13
-
-//cluster 2
-#define SER16  0
-#define SER17  1
-#define SER18  2
-#define SER19  3
-#define SER20  4
-#define SER21  5
-#define SER22  6
-#define SER23  7
-
-#define SER24  8
-#define SER25  9
-#define SER26  10
-#define SER27  11
+std::vector<Adafruit_PWMServoDriver> servoControllers;
 
 MIDI_CREATE_INSTANCE(HardwareSerial, Serial2, MIDI);
+
+struct servoCalibration {
+  int controllerIndex;
+  int servoIndex;
+  int onPWM;
+  int offPWM;
+}
+std::map<int, struct servoCalibration> servoMap;
 
 /* Calibration function
 void controlchange(byte channel, byte number, byte value){
@@ -60,76 +36,57 @@ void controlchange(byte channel, byte number, byte value){
 }
 */
 
+void setupServoMap() {
+  // Fill the servoMap with hardware indices and calibrated PWM values
+
+  //Board 1
+  servoMap.insert(std::make_pair(17, (servoCalibration){.controllerIndex=1, .servoIndex= 0, .onPWM=295, .offPWM=369})); // F0 --
+  servoMap.insert(std::make_pair(18, (servoCalibration){.controllerIndex=1, .servoIndex= 1, .onPWM=275, .offPWM=369})); // F#
+  servoMap.insert(std::make_pair(19, (servoCalibration){.controllerIndex=1, .servoIndex= 2, .onPWM=340, .offPWM=250})); // G
+  servoMap.insert(std::make_pair(20, (servoCalibration){.controllerIndex=1, .servoIndex= 3, .onPWM=369, .offPWM=295})); // G#
+  servoMap.insert(std::make_pair(21, (servoCalibration){.controllerIndex=1, .servoIndex= 4, .onPWM=369, .offPWM=250})); // A
+  servoMap.insert(std::make_pair(22, (servoCalibration){.controllerIndex=1, .servoIndex= 5, .onPWM=369, .offPWM=295})); // A#
+  servoMap.insert(std::make_pair(23, (servoCalibration){.controllerIndex=1, .servoIndex= 6, .onPWM=369, .offPWM=250})); // B
+  servoMap.insert(std::make_pair(24, (servoCalibration){.controllerIndex=1, .servoIndex= 7, .onPWM=369, .offPWM=250})); // C1 --
+
+  servoMap.insert(std::make_pair(25, (servoCalibration){.controllerIndex=1, .servoIndex= 8, .onPWM=369, .offPWM=250})); // C#
+  servoMap.insert(std::make_pair(26, (servoCalibration){.controllerIndex=1, .servoIndex= 9, .onPWM=369, .offPWM=250})); // D
+  servoMap.insert(std::make_pair(27, (servoCalibration){.controllerIndex=1, .servoIndex=10, .onPWM=369, .offPWM=295})); // D#
+  servoMap.insert(std::make_pair(28, (servoCalibration){.controllerIndex=1, .servoIndex=11, .onPWM=369, .offPWM=250})); // E
+
+  //Board 0
+  servoMap.insert(std::make_pair(29, (servoCalibration){.controllerIndex=0, .servoIndex= 0, .onPWM=369, .offPWM=295})); // F
+  servoMap.insert(std::make_pair(30, (servoCalibration){.controllerIndex=0, .servoIndex= 1, .onPWM=328, .offPWM=275})); // F#
+  servoMap.insert(std::make_pair(31, (servoCalibration){.controllerIndex=0, .servoIndex= 2, .onPWM=348, .offPWM=285})); // G
+  servoMap.insert(std::make_pair(32, (servoCalibration){.controllerIndex=0, .servoIndex= 3, .onPWM=301, .offPWM=241})); // G#
+  servoMap.insert(std::make_pair(33, (servoCalibration){.controllerIndex=0, .servoIndex= 4, .onPWM=358, .offPWM=288})); // A
+  servoMap.insert(std::make_pair(34, (servoCalibration){.controllerIndex=0, .servoIndex= 5, .onPWM=318, .offPWM=248})); // A#
+
+  servoMap.insert(std::make_pair(35, (servoCalibration){.controllerIndex=0, .servoIndex= 6, .onPWM=280, .offPWM=372})); // B
+  servoMap.insert(std::make_pair(36, (servoCalibration){.controllerIndex=0, .servoIndex= 7, .onPWM=281, .offPWM=358})); // C2 --
+  servoMap.insert(std::make_pair(37, (servoCalibration){.controllerIndex=0, .servoIndex= 8, .onPWM=300, .offPWM=385})); // C#
+  servoMap.insert(std::make_pair(38, (servoCalibration){.controllerIndex=0, .servoIndex= 9, .onPWM=250, .offPWM=335})); // D
+  servoMap.insert(std::make_pair(39, (servoCalibration){.controllerIndex=0, .servoIndex=10, .onPWM=285, .offPWM=328})); // D#
+  servoMap.insert(std::make_pair(40, (servoCalibration){.controllerIndex=0, .servoIndex=11, .onPWM=281, .offPWM=352})); // E
+  servoMap.insert(std::make_pair(41, (servoCalibration){.controllerIndex=0, .servoIndex=12, .onPWM=288, .offPWM=335})); // F
+  servoMap.insert(std::make_pair(42, (servoCalibration){.controllerIndex=0, .servoIndex=13, .onPWM=301, .offPWM=342})); // F#
+}
+
 void noteOn(byte channel, byte pitch, byte velocity){
   Serial.println(pitch);
-  switch(pitch){   
-    //Board 1
-    case 17:{pca9686.setPWM(SER16, 0, 295); break;} // F0
-    case 18:{pca9686.setPWM(SER17, 0, 275); break;} // F# 
-    case 19:{pca9686.setPWM(SER18, 0, 340); break;} // G  
-    case 20:{pca9686.setPWM(SER19, 0, 369); break;} // G# 
-    case 21:{pca9686.setPWM(SER20, 0, 369); break;} // A  
-    case 22:{pca9686.setPWM(SER21, 0, 369); break;}
-    case 23:{pca9686.setPWM(SER22, 0, 369); break;}
-    case 24:{pca9686.setPWM(SER23, 0, 369); break;}
-      
-    case 25:{pca9686.setPWM(SER24, 0, 369);  break;}
-    case 26:{pca9686.setPWM(SER25, 0, 369);  break;}
-    case 27:{pca9686.setPWM(SER26, 0, 369);  break;}
-    case 28:{pca9686.setPWM(SER27, 0, 369);  break;}
 
-    //Board 0
-    case 29:{ pca9685.setPWM(SER0, 0,369);  break;}
-    case 30:{ pca9685.setPWM(SER1, 0, 328);  break;}
-    case 31:{ pca9685.setPWM(SER2, 0, 348);  break;}
-    case 32:{ pca9685.setPWM(SER3, 0, 301);  break;}
-    case 33:{ pca9685.setPWM(SER4, 0, 358);  break;}
-    case 34:{ pca9685.setPWM(SER5, 0, 318);  break;}
-
-    case 35:{ pca9685.setPWM(SER6, 0, 280);  break;} // B1
-    case 36:{ pca9685.setPWM(SER7, 0, 281);  break;} // C1
-    case 37:{ pca9685.setPWM(SER8, 0, 300);  break;} // C#
-    case 38:{ pca9685.setPWM(SER9, 0, 250);  break;} // D
-    case 39:{ pca9685.setPWM(SER10, 0, 285);  break;}
-    case 40:{ pca9685.setPWM(SER11, 0, 281);  break;}
-    case 41:{ pca9685.setPWM(SER12, 0, 288);  break;}
-    case 42:{ pca9685.setPWM(SER13, 0, 301);  break;}
+  servoData = servoMap.find(pitch);
+  if(servoData != servoMap.end()) {
+    servoControllers[servoData.controllerIndex].setPWM(servoData.servoIndex, 0, servoData.onPWM);
+  } else {
+    Serial.println("Unmapped MIDI key!")
   }
 }
 
 void noteOff(byte channel, byte pitch, byte velocity){
-  switch(pitch){
-    //Board 1
-    case 17:{pca9686.setPWM(SER16, 0, 369); break;} // F0 --
-    case 18:{pca9686.setPWM(SER17, 0, 369); break;} // F#
-    case 19:{pca9686.setPWM(SER18, 0, 250); break;} // G 
-    case 20:{pca9686.setPWM(SER19, 0, 295); break;} // G#
-    case 21:{pca9686.setPWM(SER20, 0, 250); break;} // A 
-    case 22:{pca9686.setPWM(SER21, 0, 295); break;} // A#
-    case 23:{pca9686.setPWM(SER22, 0, 250); break;} // B 
-    case 24:{pca9686.setPWM(SER23, 0, 250); break;} // C1 --
-  
-    case 25:{pca9686.setPWM(SER24, 0, 250); break;} // C#
-    case 26:{pca9686.setPWM(SER25, 0, 250); break;} // D 
-    case 27:{pca9686.setPWM(SER26, 0, 295); break;} // D#
-    case 28:{pca9686.setPWM(SER27, 0, 250); break;} // E
-   
-    //Board 0
-    case 29:{ pca9685.setPWM(SER0, 0, 295);  break;} // F
-    case 30:{ pca9685.setPWM(SER1, 0, 275);  break;} // F#
-    case 31:{ pca9685.setPWM(SER2, 0, 285);  break;} // G
-    case 32:{ pca9685.setPWM(SER3, 0, 241);  break;} // G#
-    case 33:{ pca9685.setPWM(SER4, 0, 288);  break;} // A
-    case 34:{ pca9685.setPWM(SER5, 0, 248);  break;} // A#
-
-    case 35:{ pca9685.setPWM(SER6, 0, 372);  break;} // B
-    case 36:{ pca9685.setPWM(SER7, 0, 358);  break;} // C2 --
-    case 37:{ pca9685.setPWM(SER8, 0, 385);  break;} // C#
-    case 38:{ pca9685.setPWM(SER9, 0, 335);  break;} // D
-    case 39:{ pca9685.setPWM(SER10, 0, 328);  break;} // D#
-    case 40:{ pca9685.setPWM(SER11, 0, 352);  break;} // E
-    case 41:{ pca9685.setPWM(SER12, 0, 335);  break;} // F
-    case 42:{ pca9685.setPWM(SER13, 0, 342);  break;} // F#          
+  servoData = servoMap.find(pitch);
+  if(servoData != servoMap.end()) {
+    servoControllers[servoData.controllerIndex].setPWM(servoData.servoIndex, 0, servoData.onPWM);
   }
 }
 
@@ -141,12 +98,17 @@ void setup() {
   Serial.println("PCA9685 Servo Test");
 
   // Initialize PCA9685
+
+  Adafruit_PWMServoDriver pca9685 = Adafruit_PWMServoDriver(0x40);
   pca9685.begin();
+  pca9685.setPWMFreq(50);
+  servoControllers.push_back(pca9685);
+  Adafruit_PWMServoDriver pca9686 = Adafruit_PWMServoDriver(0x41);
   pca9686.begin();
+  pca9686.setPWMFreq(50);
+  servoControllers.push_back(pca9686);
 
   // Set PWM Frequency to 50Hz
-  pca9685.setPWMFreq(50);
-  pca9686.setPWMFreq(50);
 
   pinMode (2, OUTPUT);
   MIDI.begin(MIDI_CHANNEL_OMNI); 
@@ -158,10 +120,12 @@ void setup() {
   delay(200);
   digitalWrite(2, LOW);
   delay(200);
-   
+  
   MIDI.setHandleNoteOn(noteOn);
   MIDI.setHandleNoteOff(noteOff); 
   //MIDI.setHandleControlChange(controlchange);
+
+  setupServoMap();
 }
 
 void loop(){

--- a/ESP32_orgel_midi_in_servoboard/ESP32_orgel_midi_in_servoboard.ino
+++ b/ESP32_orgel_midi_in_servoboard/ESP32_orgel_midi_in_servoboard.ino
@@ -91,7 +91,7 @@ void noteOff(byte channel, byte pitch, byte velocity){
   auto servoData = servoMap.find(pitch);
   if(servoData != servoMap.end()) {
     servoControllers[servoData->second.controllerIndex].setPWM(
-      servoData->second.servoIndex, 0, servoData->second.onPWM
+      servoData->second.servoIndex, 0, servoData->second.offPWM
     );
   }
 }

--- a/ESP32_orgel_midi_in_servoboard/ESP32_orgel_midi_in_servoboard.ino
+++ b/ESP32_orgel_midi_in_servoboard/ESP32_orgel_midi_in_servoboard.ino
@@ -39,37 +39,39 @@ void controlchange(byte channel, byte number, byte value){
 void setupServoMap() {
   // Fill the servoMap with hardware indices and calibrated PWM values
 
-  //Board 1
-  servoMap.insert(std::make_pair(17, (servoCalibration){.controllerIndex=1, .servoIndex= 0, .onPWM=295, .offPWM=369})); // F0 --
-  servoMap.insert(std::make_pair(18, (servoCalibration){.controllerIndex=1, .servoIndex= 1, .onPWM=275, .offPWM=369})); // F#
-  servoMap.insert(std::make_pair(19, (servoCalibration){.controllerIndex=1, .servoIndex= 2, .onPWM=340, .offPWM=250})); // G
-  servoMap.insert(std::make_pair(20, (servoCalibration){.controllerIndex=1, .servoIndex= 3, .onPWM=369, .offPWM=295})); // G#
-  servoMap.insert(std::make_pair(21, (servoCalibration){.controllerIndex=1, .servoIndex= 4, .onPWM=369, .offPWM=250})); // A
-  servoMap.insert(std::make_pair(22, (servoCalibration){.controllerIndex=1, .servoIndex= 5, .onPWM=369, .offPWM=295})); // A#
-  servoMap.insert(std::make_pair(23, (servoCalibration){.controllerIndex=1, .servoIndex= 6, .onPWM=369, .offPWM=250})); // B
-  servoMap.insert(std::make_pair(24, (servoCalibration){.controllerIndex=1, .servoIndex= 7, .onPWM=369, .offPWM=250})); // C1 --
+  servoMap = std::map<int, servoCalibration> {
+    //Board 1
+    {17, {.controllerIndex=1, .servoIndex= 0, .onPWM=295, .offPWM=369}}, // F0 --
+    {18, {.controllerIndex=1, .servoIndex= 1, .onPWM=275, .offPWM=369}}, // F#
+    {19, {.controllerIndex=1, .servoIndex= 2, .onPWM=340, .offPWM=250}}, // G
+    {20, {.controllerIndex=1, .servoIndex= 3, .onPWM=369, .offPWM=295}}, // G#
+    {21, {.controllerIndex=1, .servoIndex= 4, .onPWM=369, .offPWM=250}}, // A
+    {22, {.controllerIndex=1, .servoIndex= 5, .onPWM=369, .offPWM=295}}, // A#
+    {23, {.controllerIndex=1, .servoIndex= 6, .onPWM=369, .offPWM=250}}, // B
+    {24, {.controllerIndex=1, .servoIndex= 7, .onPWM=369, .offPWM=250}}, // C1 --
 
-  servoMap.insert(std::make_pair(25, (servoCalibration){.controllerIndex=1, .servoIndex= 8, .onPWM=369, .offPWM=250})); // C#
-  servoMap.insert(std::make_pair(26, (servoCalibration){.controllerIndex=1, .servoIndex= 9, .onPWM=369, .offPWM=250})); // D
-  servoMap.insert(std::make_pair(27, (servoCalibration){.controllerIndex=1, .servoIndex=10, .onPWM=369, .offPWM=295})); // D#
-  servoMap.insert(std::make_pair(28, (servoCalibration){.controllerIndex=1, .servoIndex=11, .onPWM=369, .offPWM=250})); // E
+    {25, {.controllerIndex=1, .servoIndex= 8, .onPWM=369, .offPWM=250}}, // C#
+    {26, {.controllerIndex=1, .servoIndex= 9, .onPWM=369, .offPWM=250}}, // D
+    {27, {.controllerIndex=1, .servoIndex=10, .onPWM=369, .offPWM=295}}, // D#
+    {28, {.controllerIndex=1, .servoIndex=11, .onPWM=369, .offPWM=250}}, // E
 
-  //Board 0
-  servoMap.insert(std::make_pair(29, (servoCalibration){.controllerIndex=0, .servoIndex= 0, .onPWM=369, .offPWM=295})); // F
-  servoMap.insert(std::make_pair(30, (servoCalibration){.controllerIndex=0, .servoIndex= 1, .onPWM=328, .offPWM=275})); // F#
-  servoMap.insert(std::make_pair(31, (servoCalibration){.controllerIndex=0, .servoIndex= 2, .onPWM=348, .offPWM=285})); // G
-  servoMap.insert(std::make_pair(32, (servoCalibration){.controllerIndex=0, .servoIndex= 3, .onPWM=301, .offPWM=241})); // G#
-  servoMap.insert(std::make_pair(33, (servoCalibration){.controllerIndex=0, .servoIndex= 4, .onPWM=358, .offPWM=288})); // A
-  servoMap.insert(std::make_pair(34, (servoCalibration){.controllerIndex=0, .servoIndex= 5, .onPWM=318, .offPWM=248})); // A#
+    //Board 0
+    {29, {.controllerIndex=0, .servoIndex= 0, .onPWM=369, .offPWM=295}}, // F
+    {30, {.controllerIndex=0, .servoIndex= 1, .onPWM=328, .offPWM=275}}, // F#
+    {31, {.controllerIndex=0, .servoIndex= 2, .onPWM=348, .offPWM=285}}, // G
+    {32, {.controllerIndex=0, .servoIndex= 3, .onPWM=301, .offPWM=241}}, // G#
+    {33, {.controllerIndex=0, .servoIndex= 4, .onPWM=358, .offPWM=288}}, // A
+    {34, {.controllerIndex=0, .servoIndex= 5, .onPWM=318, .offPWM=248}}, // A#
 
-  servoMap.insert(std::make_pair(35, (servoCalibration){.controllerIndex=0, .servoIndex= 6, .onPWM=280, .offPWM=372})); // B
-  servoMap.insert(std::make_pair(36, (servoCalibration){.controllerIndex=0, .servoIndex= 7, .onPWM=281, .offPWM=358})); // C2 --
-  servoMap.insert(std::make_pair(37, (servoCalibration){.controllerIndex=0, .servoIndex= 8, .onPWM=300, .offPWM=385})); // C#
-  servoMap.insert(std::make_pair(38, (servoCalibration){.controllerIndex=0, .servoIndex= 9, .onPWM=250, .offPWM=335})); // D
-  servoMap.insert(std::make_pair(39, (servoCalibration){.controllerIndex=0, .servoIndex=10, .onPWM=285, .offPWM=328})); // D#
-  servoMap.insert(std::make_pair(40, (servoCalibration){.controllerIndex=0, .servoIndex=11, .onPWM=281, .offPWM=352})); // E
-  servoMap.insert(std::make_pair(41, (servoCalibration){.controllerIndex=0, .servoIndex=12, .onPWM=288, .offPWM=335})); // F
-  servoMap.insert(std::make_pair(42, (servoCalibration){.controllerIndex=0, .servoIndex=13, .onPWM=301, .offPWM=342})); // F#
+    {35, {.controllerIndex=0, .servoIndex= 6, .onPWM=280, .offPWM=372}}, // B
+    {36, {.controllerIndex=0, .servoIndex= 7, .onPWM=281, .offPWM=358}}, // C2 --
+    {37, {.controllerIndex=0, .servoIndex= 8, .onPWM=300, .offPWM=385}}, // C#
+    {38, {.controllerIndex=0, .servoIndex= 9, .onPWM=250, .offPWM=335}}, // D
+    {39, {.controllerIndex=0, .servoIndex=10, .onPWM=285, .offPWM=328}}, // D#
+    {40, {.controllerIndex=0, .servoIndex=11, .onPWM=281, .offPWM=352}}, // E
+    {41, {.controllerIndex=0, .servoIndex=12, .onPWM=288, .offPWM=335}}, // F
+    {42, {.controllerIndex=0, .servoIndex=13, .onPWM=301, .offPWM=342}}  // F#
+  };
 }
 
 void noteOn(byte channel, byte pitch, byte velocity){

--- a/ESP32_orgel_midi_in_servoboard/ESP32_orgel_midi_in_servoboard.ino
+++ b/ESP32_orgel_midi_in_servoboard/ESP32_orgel_midi_in_servoboard.ino
@@ -6,7 +6,7 @@
  * Choose the ESP32 Dev Module in the board manager
  * Necesery libraries:
  * - MIDI Library by Francois Best
- * - 
+ * - Adafruit PWM Servo Driver Library by Adafruit
  */
 
 //https://raw.githubusercontent.com/espressif/arduino-esp32/gh-pages/package_esp32_index.json, http://arduino.esp8266.com/stable/package_esp8266com_index.json

--- a/ESP32_orgel_midi_in_servoboard/ESP32_orgel_midi_in_servoboard.ino
+++ b/ESP32_orgel_midi_in_servoboard/ESP32_orgel_midi_in_servoboard.ino
@@ -103,21 +103,20 @@ void setup() {
   // Print to monitor
   Serial.println("PCA9685 Servo Test");
 
-  // Initialize PCA9685
+  // Initialize PCA9685 controllers
+  servoControllers = std::vector<Adafruit_PWMServoDriver> {
+    Adafruit_PWMServoDriver(0x40),
+    Adafruit_PWMServoDriver(0x41)
+  };
 
-  Adafruit_PWMServoDriver pca9685 = Adafruit_PWMServoDriver(0x40);
-  pca9685.begin();
-  pca9685.setPWMFreq(50);
-  servoControllers.push_back(pca9685);
-  Adafruit_PWMServoDriver pca9686 = Adafruit_PWMServoDriver(0x41);
-  pca9686.begin();
-  pca9686.setPWMFreq(50);
-  servoControllers.push_back(pca9686);
-
-  // Set PWM Frequency to 50Hz
+  for(auto controller : servoControllers) {
+    controller.setPWMFreq(50);
+    controller.begin();
+  }
 
   pinMode (2, OUTPUT);
   MIDI.begin(MIDI_CHANNEL_OMNI); 
+
   digitalWrite(2, HIGH);
   delay(200);
   digitalWrite(2, LOW);


### PR DESCRIPTION
This PR restructures the code so both noteOn and noteOff use a shared table of calibration data. This should make editing the calibration of on and off values less prone to breaking which note should trigger which servo.

NB: I have not tested the code (at all), and am not 100% sure the Arduino toolchain supports the std::map. But I think it is worth the experiment.